### PR TITLE
Fix segment blending "divide" mode

### DIFF
--- a/wled00/FX_fcn.cpp
+++ b/wled00/FX_fcn.cpp
@@ -1286,9 +1286,9 @@ static uint8_t _average   (uint8_t a, uint8_t b) { return (a + b) >> 1; }
 #ifdef CONFIG_IDF_TARGET_ESP32C3
 static uint8_t _multiply  (uint8_t a, uint8_t b) { return ((a * b) + 255) >> 8; } // faster than division on C3 but slightly less accurate
 #else
-static uint8_t _multiply  (uint8_t a, uint8_t b) { return (a * b) / 255; } // origianl uses a & b in range [0,1]
+static uint8_t _multiply  (uint8_t a, uint8_t b) { return (a * b) / 255; } // original uses a & b in range [0,1]
 #endif
-static uint8_t _divide    (uint8_t a, uint8_t b) { return a > b ? (b * 255) / a : 255; }
+static uint8_t _divide    (uint8_t a, uint8_t b) { return a > 0 ? (b * 255) / a : 255; }
 static uint8_t _lighten   (uint8_t a, uint8_t b) { return a > b ? a : b; }
 static uint8_t _darken    (uint8_t a, uint8_t b) { return a < b ? a : b; }
 static uint8_t _screen    (uint8_t a, uint8_t b) { return 255 - _multiply(~a,~b); } // 255 - (255-a)*(255-b)/255


### PR DESCRIPTION
Not directly related to my changes, but I have a general question/concern about these blend functions. They all have uint8_t inputs and outputs, but what type is used for intermediate results? For example, multiply is `(a * b) / 255`, so what type is used to compute `a * b`? Does it promote `a` and `b` to something bigger than 8 bits before doing math? Or at least allow the result to be bigger than 8 bits? If so, is it 16 or 32 bits? Signed or unsigned?

I ask this because of the potential for over/underflow in some places. In `_add`, if `a + b` is computed in 8-bits before assigning to `t`, it could overflow. That's easy to avoid with one explicit cast: `t = (uint32_t)a + b`. A similar thing applies in `_average`, `_multiply`, and `_softlight`.

`_softlight` has another potential issue. If `a` >= 128, then `255 - 2 * a` will be less than 0. That's a problem if it gets computed with unsigned integers. (Maybe this is why the "Photoshop" formula uses different equations if `a` < 0.5 or not.) But I think you can avoid this potential problem with one more cast: `255 - 2 * (int32_t)a`.

Finally, here a couple very minor suggestions to improve clarity:

1. In `_add`, use an explicit type like `uint32_t` instead of `unsigned`.
2. Change `a` to `t` for "top layer" which pairs nicely with `b` for "bottom layer".